### PR TITLE
Add the -Ref suffix to the reference structure, implement Copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Added
 
 - All the wrapper structures now implement `Deref` of the wrapped `leap-sys` structures
+- All the reference wrapper structures now implement `Clone` and `Copy`
 - The opt-in features `glam` and `nalgebra` add conversion method for vectors and quaternions to these libraries.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 - Improved the examples to avoid common timeout unwrap()
 - The vectors and quaternion are not anymore copied
+- **Breaking** All the non-owning wrappers (most of them) are now named with `Ref` as a suffix.
+    `Hand` becomes `HandRef`, `Digit` becomes `DigitRef`, etc...
 
 ### Removed
 
-- **Breaking** All the trivial accessor functions were removed, in favour of the `Deref` trait.
+- **Breaking** All the trivial accessor functions were removed, in favour of the `Deref` trait
 
 ### Fixed
 

--- a/examples/count_hands.rs
+++ b/examples/count_hands.rs
@@ -6,7 +6,7 @@ fn main() {
     loop {
         if let Ok(msg) = c.poll(1000) {
             match msg.event() {
-                Event::Tracking(e) => println!("{} hand(s)", e.hands().len()),
+                EventRef::Tracking(e) => println!("{} hand(s)", e.hands().len()),
                 _ => {}
             }
         }

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -9,7 +9,7 @@ fn main() {
     connection.open().expect("Failed to open the connection");
 
     connection.wait_for("Connecting to the service...".to_string(), |e| match e {
-        Event::Connection(e) => {
+        EventRef::Connection(e) => {
             let flags = e.flags();
             Msg::Success(format!("Connected. Service state: {:?}", flags))
         }
@@ -17,7 +17,7 @@ fn main() {
     });
 
     connection.wait_for("Waiting for a device...".to_string(), |e| match e {
-        Event::Device(e) => {
+        EventRef::Device(e) => {
             let device_info = e
                 .device()
                 .open()
@@ -46,7 +46,7 @@ fn main() {
         connection.wait_for(
             "Waiting for the tracking mode message...".to_string(),
             |e| match e {
-                Event::TrackingMode(e) => {
+                EventRef::TrackingMode(e) => {
                     Msg::Success(format!("Tracking mode: {:#?}", e.current_tracking_mode()))
                 }
                 _ => Msg::None,
@@ -55,7 +55,7 @@ fn main() {
     }
 
     connection.wait_for("Waiting for a hand...".to_string(), |e| match e {
-        Event::Tracking(e) => {
+        EventRef::Tracking(e) => {
             if !e.hands().is_empty() {
                 Msg::Success("Got a hand".to_string())
             } else {
@@ -66,7 +66,7 @@ fn main() {
     });
 
     connection.wait_for("Close the hand".to_string(), |e| match e {
-        Event::Tracking(e) => {
+        EventRef::Tracking(e) => {
             if let Some(hand) = e.hands().first() {
                 let grab_strength = hand.grab_strength;
                 if grab_strength >= 1.0 {
@@ -82,7 +82,7 @@ fn main() {
     });
 
     connection.wait_for("Open the hand".to_string(), |e| match e {
-        Event::Tracking(e) => {
+        EventRef::Tracking(e) => {
             if let Some(hand) = e.hands().first() {
                 let ungrab_strength = 1.0 - hand.grab_strength;
                 if ungrab_strength >= 0.999 {
@@ -102,7 +102,7 @@ fn main() {
         .expect("Failed to set policy flags");
 
     connection.wait_for("Reading image".to_string(), |e| match e {
-        Event::Image(e) => {
+        EventRef::Image(e) => {
             let w = e.images()[0].properties().width;
             let h = e.images()[0].properties().height;
             let images = e.images();
@@ -130,13 +130,13 @@ pub enum Msg {
 trait WaitFor {
     fn wait_for<F>(&mut self, message: String, condition: F)
     where
-        F: Fn(&Event) -> Msg;
+        F: Fn(&EventRef) -> Msg;
 }
 
 impl WaitFor for Connection {
     fn wait_for<F>(&mut self, message: String, condition: F)
     where
-        F: Fn(&Event) -> Msg,
+        F: Fn(&EventRef) -> Msg,
     {
         let mut throbber = Throbber::new().interval(Duration::from_millis(100));
 

--- a/examples/watch_events.rs
+++ b/examples/watch_events.rs
@@ -8,30 +8,30 @@ fn main() {
     loop {
         if let Ok(message) = connection.poll(1000) {
             match message.event() {
-                Event::None => println!("None"),
-                Event::Connection(_) => println!("Connection"),
-                Event::ConnectionLost(_) => println!("ConnectionLost"),
-                Event::Device(_) => println!("Device"),
-                Event::DeviceFailure(_) => println!("DeviceFailure"),
-                Event::Policy(_) => println!("Policy"),
-                Event::Tracking(_) => {} // spam
-                Event::ImageRequestError => println!("ImageRequestError"),
-                Event::ImageComplete => println!("ImageComplete"),
-                Event::LogEvent(_) => println!("Log"),
-                Event::DeviceLost => println!("DeviceLost"),
-                Event::ConfigResponse(_) => println!("ConfigResponse"),
-                Event::ConfigChange(_) => println!("ConfigChange"),
-                Event::DeviceStatusChange(_) => println!("DeviceStatusChange"),
-                Event::DroppedFrame(_) => println!("DroppedFrame"),
-                Event::Image(_) => println!("Image"),
-                Event::PointMappingChange(_) => println!("PointMappingChange"),
+                EventRef::None => println!("None"),
+                EventRef::Connection(_) => println!("Connection"),
+                EventRef::ConnectionLost(_) => println!("ConnectionLost"),
+                EventRef::Device(_) => println!("Device"),
+                EventRef::DeviceFailure(_) => println!("DeviceFailure"),
+                EventRef::Policy(_) => println!("Policy"),
+                EventRef::Tracking(_) => {} // spam
+                EventRef::ImageRequestError => println!("ImageRequestError"),
+                EventRef::ImageComplete => println!("ImageComplete"),
+                EventRef::LogEvent(_) => println!("Log"),
+                EventRef::DeviceLost => println!("DeviceLost"),
+                EventRef::ConfigResponse(_) => println!("ConfigResponse"),
+                EventRef::ConfigChange(_) => println!("ConfigChange"),
+                EventRef::DeviceStatusChange(_) => println!("DeviceStatusChange"),
+                EventRef::DroppedFrame(_) => println!("DroppedFrame"),
+                EventRef::Image(_) => println!("Image"),
+                EventRef::PointMappingChange(_) => println!("PointMappingChange"),
                 #[cfg(feature = "gemini")]
-                Event::TrackingMode(_) => println!("TrackingMode"),
-                Event::LogEvents(_) => println!("LogEvents"),
-                Event::HeadPose(_) => println!("HeadPose"),
-                Event::Eyes(_) => println!("Eyes"),
-                Event::IMU(_) => println!("IMU"),
-                Event::Unknown(_) => println!("Unknown"),
+                EventRef::TrackingMode(_) => println!("TrackingMode"),
+                EventRef::LogEvents(_) => println!("LogEvents"),
+                EventRef::HeadPose(_) => println!("HeadPose"),
+                EventRef::Eyes(_) => println!("Eyes"),
+                EventRef::IMU(_) => println!("IMU"),
+                EventRef::Unknown(_) => println!("Unknown"),
             }
         }
     }

--- a/src/bone.rs
+++ b/src/bone.rs
@@ -1,30 +1,30 @@
 use derive_deref::Deref;
 use leap_sys::LEAP_BONE;
 
-use crate::{LeapVector, Quaternion};
+use crate::{LeapVectorRef, QuaternionRef};
 
 #[doc = " Describes a bone's position and orientation."]
 #[doc = ""]
 #[doc = " Bones are members of the LEAP_DIGIT struct."]
 #[doc = " @since 3.0.0"]
 #[derive(Deref)]
-pub struct Bone<'a>(pub(crate) &'a LEAP_BONE);
+pub struct BoneRef<'a>(pub(crate) &'a LEAP_BONE);
 
-impl<'a> Bone<'a> {
+impl<'a> BoneRef<'a> {
     #[doc = " The base of the bone, closer to the heart. The bones origin. @since 3.0.0"]
-    pub fn prev_joint(&self) -> LeapVector {
-        LeapVector::from(&self.prev_joint)
+    pub fn prev_joint(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.prev_joint)
     }
 
     #[doc = " The end of the bone, further from the heart. @since 3.0.0"]
-    pub fn next_joint(&self) -> LeapVector {
-        LeapVector::from(&self.next_joint)
+    pub fn next_joint(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.next_joint)
     }
 
     #[doc = " Rotation in world space from the forward direction."]
     #[doc = " Convert the quaternion to a matrix to derive the basis vectors."]
     #[doc = " @since 3.1.2"]
-    pub fn rotation(&self) -> Quaternion {
-        Quaternion::from(&self.rotation)
+    pub fn rotation(&self) -> QuaternionRef {
+        QuaternionRef::from(&self.rotation)
     }
 }

--- a/src/bone.rs
+++ b/src/bone.rs
@@ -7,7 +7,7 @@ use crate::{LeapVectorRef, QuaternionRef};
 #[doc = ""]
 #[doc = " Bones are members of the LEAP_DIGIT struct."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct BoneRef<'a>(pub(crate) &'a LEAP_BONE);
 
 impl<'a> BoneRef<'a> {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -857,7 +857,7 @@ mod tests {
 
             connection
                 .wait_for(|e| match e {
-                    Event::Policy(_) => Some(()),
+                    EventRef::Policy(_) => Some(()),
                     _ => None,
                 })
                 .expect("Did not receive policy change");
@@ -916,7 +916,7 @@ mod tests {
                 // Note: If events are not polled, the frame interpolation fails with "is not seer"
                 connection
                     .wait_for(|e| match e {
-                        Event::Tracking(_) => Some(()),
+                        EventRef::Tracking(_) => Some(()),
                         _ => None,
                     })
                     .expect("no tracking data");
@@ -1003,7 +1003,7 @@ mod tests {
             .expect("Failed to request the config value");
         connection
             .wait_for(|e| match e {
-                Event::ConfigResponse(c) => {
+                EventRef::ConfigResponse(c) => {
                     if c.requestID != request_id {
                         None
                     } else if let Variant::Boolean(robust_mode_enabled) = c.value() {
@@ -1028,7 +1028,7 @@ mod tests {
             // Note: If events are not polled, the frame interpolation fails with "is not seer"
             connection
                 .wait_for(|e| match e {
-                    Event::Tracking(_) => Some(()),
+                    EventRef::Tracking(_) => Some(()),
                     _ => None,
                 })
                 .expect("no tracking data");
@@ -1066,7 +1066,7 @@ mod tests {
 
         connection
             .wait_for(|e| match e {
-                Event::Policy(_) => Some(()),
+                EventRef::Policy(_) => Some(()),
                 _ => None,
             })
             .expect("Did not receive policy change");

--- a/src/connection_info.rs
+++ b/src/connection_info.rs
@@ -10,7 +10,7 @@ use crate::ConnectionStatus;
 #[doc = " call LeapOpenConnection() to establish the connection; then call"]
 #[doc = " LeapGetConnectionInfo(), which creates this struct, to check the connection status."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct ConnectionInfo(pub(crate) LEAP_CONNECTION_INFO);
 
 impl ConnectionInfo {

--- a/src/connection_message.rs
+++ b/src/connection_message.rs
@@ -1,7 +1,7 @@
 use derive_deref::Deref;
 use leap_sys::LEAP_CONNECTION_MESSAGE;
 
-use crate::event::Event;
+use crate::event::EventRef;
 
 #[doc = " Defines a basic message from the LeapC message queue."]
 #[doc = " Set by calling LeapPollConnection()."]
@@ -11,7 +11,7 @@ pub struct ConnectionMessage(pub(crate) LEAP_CONNECTION_MESSAGE);
 
 impl ConnectionMessage {
     #[doc = " A pointer to the event data for the current type of message. @since 3.0.0"]
-    pub fn event(&self) -> Event {
+    pub fn event(&self) -> EventRef {
         (self.type_, &self.__bindgen_anon_1).into()
     }
 }

--- a/src/connection_message.rs
+++ b/src/connection_message.rs
@@ -6,7 +6,7 @@ use crate::event::EventRef;
 #[doc = " Defines a basic message from the LeapC message queue."]
 #[doc = " Set by calling LeapPollConnection()."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct ConnectionMessage(pub(crate) LEAP_CONNECTION_MESSAGE);
 
 impl ConnectionMessage {

--- a/src/device_ref.rs
+++ b/src/device_ref.rs
@@ -8,7 +8,7 @@ use crate::Device;
 #[doc = " Get a LEAP_DEVICE_REF by calling LeapGetDeviceList(). Access a device by"]
 #[doc = " calling LeapOpenDevice() with this reference. LeapOpenDevice() provides a"]
 #[doc = " LEAP_DEVICE struct, which is a handle to an open device."]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct DeviceRef(pub(crate) LEAP_DEVICE_REF);
 
 impl DeviceRef {

--- a/src/digit.rs
+++ b/src/digit.rs
@@ -6,7 +6,7 @@ use crate::BoneRef;
 #[doc = " Describes the digit of a hand."]
 #[doc = " Digits are members of the LEAP_HAND struct."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct DigitRef<'a>(pub(crate) &'a LEAP_DIGIT);
 
 impl<'a> DigitRef<'a> {

--- a/src/digit.rs
+++ b/src/digit.rs
@@ -1,24 +1,24 @@
 use derive_deref::Deref;
 use leap_sys::LEAP_DIGIT;
 
-use crate::Bone;
+use crate::BoneRef;
 
 #[doc = " Describes the digit of a hand."]
 #[doc = " Digits are members of the LEAP_HAND struct."]
 #[doc = " @since 3.0.0"]
 #[derive(Deref)]
-pub struct Digit<'a>(pub(crate) &'a LEAP_DIGIT);
+pub struct DigitRef<'a>(pub(crate) &'a LEAP_DIGIT);
 
-impl<'a> Digit<'a> {
+impl<'a> DigitRef<'a> {
     #[doc = " All the bones of a digit as an iterable collection. @since 3.0.0"]
-    pub fn bones(&self) -> [Bone; 4] {
+    pub fn bones(&self) -> [BoneRef; 4] {
         let bones;
         unsafe { bones = &self.__bindgen_anon_1.bones }
         [
-            Bone(&bones[0]),
-            Bone(&bones[1]),
-            Bone(&bones[2]),
-            Bone(&bones[3]),
+            BoneRef(&bones[0]),
+            BoneRef(&bones[1]),
+            BoneRef(&bones[2]),
+            BoneRef(&bones[3]),
         ]
     }
 
@@ -29,22 +29,22 @@ impl<'a> Digit<'a> {
     #[doc = " is absent in a real thumb, rather than the metacarpal bone. In the Ultraleap Tracking model,"]
     #[doc = " however, we use a \"zero\" metacarpal bone instead for ease of programming."]
     #[doc = " @since 3.0.0"]
-    pub fn metacarpal(&self) -> Bone {
-        unsafe { Bone(&self.__bindgen_anon_1.__bindgen_anon_1.metacarpal) }
+    pub fn metacarpal(&self) -> BoneRef {
+        unsafe { BoneRef(&self.__bindgen_anon_1.__bindgen_anon_1.metacarpal) }
     }
 
     #[doc = " The phalange extending from the knuckle. @since 3.0.0"]
-    pub fn proximal(&self) -> Bone {
-        unsafe { Bone(&self.__bindgen_anon_1.__bindgen_anon_1.proximal) }
+    pub fn proximal(&self) -> BoneRef {
+        unsafe { BoneRef(&self.__bindgen_anon_1.__bindgen_anon_1.proximal) }
     }
 
-    pub fn intermediate(&self) -> Bone {
-        unsafe { Bone(&self.__bindgen_anon_1.__bindgen_anon_1.intermediate) }
+    pub fn intermediate(&self) -> BoneRef {
+        unsafe { BoneRef(&self.__bindgen_anon_1.__bindgen_anon_1.intermediate) }
     }
 
     #[doc = " The bone between the proximal phalange and the distal phalange. @since 3.0.0"]
-    pub fn distal(&self) -> Bone {
-        unsafe { Bone(&self.__bindgen_anon_1.__bindgen_anon_1.distal) }
+    pub fn distal(&self) -> BoneRef {
+        unsafe { BoneRef(&self.__bindgen_anon_1.__bindgen_anon_1.distal) }
     }
 
     #[doc = " Reports whether the finger is more or less straight. @since 3.0.0"]

--- a/src/distortion_matrix.rs
+++ b/src/distortion_matrix.rs
@@ -12,7 +12,7 @@ use leap_sys::LEAP_DISTORTION_MATRIX;
 #[doc = " Current devices use a 64x64 point distortion grid."]
 #[doc = " @since 3.0.0"]
 #[derive(Deref)]
-pub struct DistortionMatrix<'a>(pub(crate) &'a LEAP_DISTORTION_MATRIX);
+pub struct DistortionMatrixRef<'a>(pub(crate) &'a LEAP_DISTORTION_MATRIX);
 
 #[doc = " A point in the distortion grid. @since 3.0.0"]
 pub struct Point {
@@ -20,7 +20,7 @@ pub struct Point {
     pub y: f32,
 }
 
-impl<'a> DistortionMatrix<'a> {
+impl<'a> DistortionMatrixRef<'a> {
     #[doc = " A grid of 2D points. @since 3.0.0"]
     pub fn matrix(&self) -> [[Point; 64]; 64] {
         self.matrix.map(|v| v.map(|p| Point { x: p.x, y: p.y }))

--- a/src/distortion_matrix.rs
+++ b/src/distortion_matrix.rs
@@ -11,7 +11,7 @@ use leap_sys::LEAP_DISTORTION_MATRIX;
 #[doc = ""]
 #[doc = " Current devices use a 64x64 point distortion grid."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct DistortionMatrixRef<'a>(pub(crate) &'a LEAP_DISTORTION_MATRIX);
 
 #[doc = " A point in the distortion grid. @since 3.0.0"]

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,37 +2,37 @@ use crate::events::*;
 use leap_sys::*;
 
 #[doc = " The types of event messages resulting from calling LeapPollConnection()."]
-pub enum Event<'a> {
+pub enum EventRef<'a> {
     #[doc = " No event has occurred within the timeout period specified when calling LeapPollConnection()."]
     #[doc = " @since 3.0.0"]
     None,
     #[doc = " A connection to the Ultraleap Tracking Service has been established."]
     #[doc = " @since 3.0.0"]
-    Connection(ConnectionEvent<'a>),
+    Connection(ConnectionEventRef<'a>),
     #[doc = " The connection to the Ultraleap Tracking Service has been lost."]
     #[doc = " @since 3.0.0"]
-    ConnectionLost(ConnectionLostEvent<'a>),
+    ConnectionLost(ConnectionLostEventRef<'a>),
     #[doc = " A device has been detected or plugged-in."]
     #[doc = " A device event is dispatched after a connection is established for any"]
     #[doc = " devices already plugged in. (The system currently only supports one"]
     #[doc = " streaming device at a time.)"]
     #[doc = " @since 3.0.0"]
-    Device(DeviceEvent<'a>),
+    Device(DeviceEventRef<'a>),
     #[doc = " A device has failed."]
     #[doc = " Device failure could be caused by hardware failure, USB controller issues, or"]
     #[doc = " other system instability. Note that unplugging a device generates an"]
     #[doc = " eLeapEventType_DeviceLost event message, not a failure message."]
     #[doc = " @since 3.0.0"]
-    DeviceFailure(DeviceFailureEvent<'a>),
+    DeviceFailure(DeviceFailureEventRef<'a>),
     #[doc = " A policy change has occurred."]
     #[doc = " This can be due to setting a policy with LeapSetPolicyFlags() or due to changing"]
     #[doc = " or policy-related config settings, including images_mode."]
     #[doc = " (A user can also change these policies using the Ultraleap Tracking Control Panel.)"]
     #[doc = " @since 3.0.0"]
-    Policy(PolicyEvent<'a>),
+    Policy(PolicyEventRef<'a>),
     #[doc = " A tracking frame. The message contains the tracking data for the frame."]
     #[doc = " @since 3.0.0"]
-    Tracking(TrackingEvent<'a>),
+    Tracking(TrackingEventRef<'a>),
     #[doc = " The request for an image has failed."]
     #[doc = " The message contains information about the failure. The client application"]
     #[doc = " will not receive the requested image set."]
@@ -44,7 +44,7 @@ pub enum Event<'a> {
     #[doc = " @since 3.0.0"]
     ImageComplete,
     #[doc = " A system message. @since 3.0.0"]
-    LogEvent(LogEvent<'a>),
+    LogEvent(LogEventRef<'a>),
     #[doc = " The device connection has been lost."]
     #[doc = ""]
     #[doc = " This event is generally asserted when the device has been detached from the system, when the"]
@@ -57,120 +57,124 @@ pub enum Event<'a> {
     #[doc = " The asynchronous response to a call to LeapRequestConfigValue()."]
     #[doc = " Contains the value of requested configuration item."]
     #[doc = " @since 3.0.0"]
-    ConfigResponse(ConfigResponseEvent<'a>),
+    ConfigResponse(ConfigResponseEventRef<'a>),
     #[doc = " The asynchronous response to a call to LeapSaveConfigValue()."]
     #[doc = " Reports whether the change succeeded or failed."]
     #[doc = " @since 3.0.0"]
-    ConfigChange(ConfigChangeEvent<'a>),
+    ConfigChange(ConfigChangeEventRef<'a>),
     #[doc = " Notification that a status change has been detected on an attached device"]
     #[doc = ""]
     #[doc = " @since 3.1.3"]
-    DeviceStatusChange(DeviceStatusChangeEvent<'a>),
+    DeviceStatusChange(DeviceStatusChangeEventRef<'a>),
     #[doc = " Notification that a status change has been detected on an attached device"]
     #[doc = ""]
     #[doc = " @since 3.1.3"]
-    DroppedFrame(DroppedFrameEvent<'a>),
+    DroppedFrame(DroppedFrameEventRef<'a>),
     #[doc = " Notification that an unrequested stereo image pair is available"]
     #[doc = ""]
     #[doc = " @since 4.0.0"]
-    Image(ImageEvent<'a>),
+    Image(ImageEventRef<'a>),
     #[doc = " Notification that point mapping has changed"]
     #[doc = ""]
     #[doc = " @since 4.0.0"]
-    PointMappingChange(PointMappingChangeEvent<'a>),
+    PointMappingChange(PointMappingChangeEventRef<'a>),
     #[doc = " A tracking mode change has occurred."]
     #[doc = " This can be due to changing the hmd or screentop policy with LeapSetPolicyFlags()."]
     #[doc = " or setting the tracking mode using LeapSetTrackingMode()."]
     #[doc = " @since 5.0.0"]
     #[cfg(feature = "gemini")]
-    TrackingMode(crate::TrackingModeEvent<'a>),
+    TrackingMode(crate::TrackingModeEventRef<'a>),
     #[doc = " An array of system messages. @since 4.0.0"]
-    LogEvents(LogEvents<'a>),
+    LogEvents(LogEventsRef<'a>),
     #[doc = " A head pose. The message contains the timestamped head position and orientation."]
     #[doc = " @since 4.1.0"]
-    HeadPose(HeadPoseEvent<'a>),
+    HeadPose(HeadPoseEventRef<'a>),
     #[doc = " Tracked eye positions. @since 4.1.0"]
-    Eyes(EyeEvent<'a>),
+    Eyes(EyeEventRef<'a>),
     #[doc = " An IMU reading. @since 4.1.0"]
-    IMU(ImuEvent<'a>),
+    IMU(ImuEventRef<'a>),
 
     Unknown(eLeapEventType),
 }
 
-impl<'a> From<(eLeapEventType, &'a _LEAP_CONNECTION_MESSAGE__bindgen_ty_1)> for Event<'a> {
+impl<'a> From<(eLeapEventType, &'a _LEAP_CONNECTION_MESSAGE__bindgen_ty_1)> for EventRef<'a> {
     fn from(
         (event_type, event): (eLeapEventType, &'a _LEAP_CONNECTION_MESSAGE__bindgen_ty_1),
     ) -> Self {
         // Combine the event type and the corresponding union to get a strongly typed enum
         match event_type {
-            leap_sys::_eLeapEventType_eLeapEventType_None => Event::None,
+            leap_sys::_eLeapEventType_eLeapEventType_None => EventRef::None,
             leap_sys::_eLeapEventType_eLeapEventType_Connection => {
-                Event::Connection(ConnectionEvent(unsafe { &*event.connection_event }))
+                EventRef::Connection(ConnectionEventRef(unsafe { &*event.connection_event }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_ConnectionLost => {
-                Event::ConnectionLost(ConnectionLostEvent(unsafe {
+                EventRef::ConnectionLost(ConnectionLostEventRef(unsafe {
                     &*event.connection_lost_event
                 }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_Device => {
-                Event::Device(DeviceEvent(unsafe { &*event.device_event }))
+                EventRef::Device(DeviceEventRef(unsafe { &*event.device_event }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_DeviceFailure => {
-                Event::DeviceFailure(DeviceFailureEvent(unsafe { &*event.device_failure_event }))
+                EventRef::DeviceFailure(DeviceFailureEventRef(unsafe {
+                    &*event.device_failure_event
+                }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_Policy => {
-                Event::Policy(PolicyEvent(unsafe { &*event.policy_event }))
+                EventRef::Policy(PolicyEventRef(unsafe { &*event.policy_event }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_Tracking => {
-                Event::Tracking(TrackingEvent(unsafe { &*event.tracking_event }))
+                EventRef::Tracking(TrackingEventRef(unsafe { &*event.tracking_event }))
             }
-            leap_sys::_eLeapEventType_eLeapEventType_ImageRequestError => Event::ImageRequestError,
-            leap_sys::_eLeapEventType_eLeapEventType_ImageComplete => Event::ImageComplete,
+            leap_sys::_eLeapEventType_eLeapEventType_ImageRequestError => {
+                EventRef::ImageRequestError
+            }
+            leap_sys::_eLeapEventType_eLeapEventType_ImageComplete => EventRef::ImageComplete,
             leap_sys::_eLeapEventType_eLeapEventType_LogEvent => {
-                Event::LogEvent(LogEvent(unsafe { &*event.log_event }))
+                EventRef::LogEvent(LogEventRef(unsafe { &*event.log_event }))
             }
-            leap_sys::_eLeapEventType_eLeapEventType_DeviceLost => Event::DeviceLost,
+            leap_sys::_eLeapEventType_eLeapEventType_DeviceLost => EventRef::DeviceLost,
             leap_sys::_eLeapEventType_eLeapEventType_ConfigResponse => {
-                Event::ConfigResponse(ConfigResponseEvent(unsafe {
+                EventRef::ConfigResponse(ConfigResponseEventRef(unsafe {
                     &*event.config_response_event
                 }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_ConfigChange => {
-                Event::ConfigChange(ConfigChangeEvent(unsafe { &*event.config_change_event }))
+                EventRef::ConfigChange(ConfigChangeEventRef(unsafe { &*event.config_change_event }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_DeviceStatusChange => {
-                Event::DeviceStatusChange(DeviceStatusChangeEvent(unsafe {
+                EventRef::DeviceStatusChange(DeviceStatusChangeEventRef(unsafe {
                     &*event.device_status_change_event
                 }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_DroppedFrame => {
-                Event::DroppedFrame(DroppedFrameEvent(unsafe { &*event.dropped_frame_event }))
+                EventRef::DroppedFrame(DroppedFrameEventRef(unsafe { &*event.dropped_frame_event }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_Image => {
-                Event::Image(ImageEvent(unsafe { &*event.image_event }))
+                EventRef::Image(ImageEventRef(unsafe { &*event.image_event }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_PointMappingChange => {
-                Event::PointMappingChange(PointMappingChangeEvent(unsafe {
+                EventRef::PointMappingChange(PointMappingChangeEventRef(unsafe {
                     &*event.point_mapping_change_event
                 }))
             }
             #[cfg(feature = "gemini")]
             leap_sys::_eLeapEventType_eLeapEventType_TrackingMode => {
-                Event::TrackingMode(TrackingModeEvent(unsafe { &*event.tracking_mode_event }))
+                EventRef::TrackingMode(TrackingModeEventRef(unsafe { &*event.tracking_mode_event }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_LogEvents => {
-                Event::LogEvents(LogEvents(unsafe { &*event.log_events }))
+                EventRef::LogEvents(LogEventsRef(unsafe { &*event.log_events }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_HeadPose => {
-                Event::HeadPose(HeadPoseEvent(unsafe { &*event.head_pose_event }))
+                EventRef::HeadPose(HeadPoseEventRef(unsafe { &*event.head_pose_event }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_Eyes => {
-                Event::Eyes(EyeEvent(unsafe { &*event.eye_event }))
+                EventRef::Eyes(EyeEventRef(unsafe { &*event.eye_event }))
             }
             leap_sys::_eLeapEventType_eLeapEventType_IMU => {
-                Event::IMU(ImuEvent(unsafe { &*event.imu_event }))
+                EventRef::IMU(ImuEventRef(unsafe { &*event.imu_event }))
             }
-            event_code => Event::Unknown(event_code),
+            event_code => EventRef::Unknown(event_code),
         }
     }
 }

--- a/src/events/config_change_event.rs
+++ b/src/events/config_change_event.rs
@@ -10,4 +10,4 @@ use leap_sys::LEAP_CONFIG_CHANGE_EVENT;
 #[doc = " @returns The operation result code, a member of the eLeapRS enumeration."]
 #[doc = " @since 3.0.0"]
 #[derive(Deref)]
-pub struct ConfigChangeEvent<'a>(pub(crate) &'a LEAP_CONFIG_CHANGE_EVENT);
+pub struct ConfigChangeEventRef<'a>(pub(crate) &'a LEAP_CONFIG_CHANGE_EVENT);

--- a/src/events/config_change_event.rs
+++ b/src/events/config_change_event.rs
@@ -9,5 +9,5 @@ use leap_sys::LEAP_CONFIG_CHANGE_EVENT;
 #[doc = " value to correlate the response to the originating request."]
 #[doc = " @returns The operation result code, a member of the eLeapRS enumeration."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct ConfigChangeEventRef<'a>(pub(crate) &'a LEAP_CONFIG_CHANGE_EVENT);

--- a/src/events/config_response_event.rs
+++ b/src/events/config_response_event.rs
@@ -10,9 +10,9 @@ use crate::Variant;
 #[doc = " value to correlate the response to the originating request."]
 #[doc = " @since 3.0.0"]
 #[derive(Deref)]
-pub struct ConfigResponseEvent<'a>(pub(crate) &'a LEAP_CONFIG_RESPONSE_EVENT);
+pub struct ConfigResponseEventRef<'a>(pub(crate) &'a LEAP_CONFIG_RESPONSE_EVENT);
 
-impl<'a> ConfigResponseEvent<'a> {
+impl<'a> ConfigResponseEventRef<'a> {
     #[doc = " The configuration value retrieved from the service. Do not free any memory pointed to by"]
     #[doc = " this member. The value held is only valid until the next call to LeapPollConnection()."]
     #[doc = " @since 3.0.0"]

--- a/src/events/config_response_event.rs
+++ b/src/events/config_response_event.rs
@@ -9,7 +9,7 @@ use crate::Variant;
 #[doc = " returns this event structure when the request has been processed. Use the requestID"]
 #[doc = " value to correlate the response to the originating request."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct ConfigResponseEventRef<'a>(pub(crate) &'a LEAP_CONFIG_RESPONSE_EVENT);
 
 impl<'a> ConfigResponseEventRef<'a> {

--- a/src/events/connection_event.rs
+++ b/src/events/connection_event.rs
@@ -6,7 +6,7 @@ use crate::ServiceState;
 #[doc = "  \\ingroup Structs"]
 #[doc = " Received from LeapPollConnection() when a connection to the Ultraleap Tracking Service is established."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct ConnectionEventRef<'a>(pub(crate) &'a LEAP_CONNECTION_EVENT);
 
 impl<'a> ConnectionEventRef<'a> {

--- a/src/events/connection_event.rs
+++ b/src/events/connection_event.rs
@@ -7,9 +7,9 @@ use crate::ServiceState;
 #[doc = " Received from LeapPollConnection() when a connection to the Ultraleap Tracking Service is established."]
 #[doc = " @since 3.0.0"]
 #[derive(Deref)]
-pub struct ConnectionEvent<'a>(pub(crate) &'a LEAP_CONNECTION_EVENT);
+pub struct ConnectionEventRef<'a>(pub(crate) &'a LEAP_CONNECTION_EVENT);
 
-impl<'a> ConnectionEvent<'a> {
+impl<'a> ConnectionEventRef<'a> {
     #[doc = " A combination of eLeapServiceDisposition flags. @since 3.1.3"]
     pub fn flags(&self) -> ServiceState {
         ServiceState::from_bits_truncate(self.flags)
@@ -28,7 +28,7 @@ mod tests {
         connection.open().expect("Failed to open the connection");
         let _flags = connection
             .wait_for(|e| match e {
-                Event::Connection(e) => Some(e.flags()),
+                EventRef::Connection(e) => Some(e.flags()),
                 _ => None,
             })
             .expect("Did not receive a connection event.");

--- a/src/events/connection_lost_event.rs
+++ b/src/events/connection_lost_event.rs
@@ -8,7 +8,7 @@ use leap_sys::LEAP_CONNECTION_LOST_EVENT;
 #[doc = " this event. Otherwise, it can take up to 5 seconds of polling the connection to"]
 #[doc = " receive this event."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct ConnectionLostEventRef<'a>(pub(crate) &'a LEAP_CONNECTION_LOST_EVENT);
 
 // No impl for now, only reserved fields.

--- a/src/events/connection_lost_event.rs
+++ b/src/events/connection_lost_event.rs
@@ -9,6 +9,6 @@ use leap_sys::LEAP_CONNECTION_LOST_EVENT;
 #[doc = " receive this event."]
 #[doc = " @since 3.0.0"]
 #[derive(Deref)]
-pub struct ConnectionLostEvent<'a>(pub(crate) &'a LEAP_CONNECTION_LOST_EVENT);
+pub struct ConnectionLostEventRef<'a>(pub(crate) &'a LEAP_CONNECTION_LOST_EVENT);
 
 // No impl for now, only reserved fields.

--- a/src/events/device_event.rs
+++ b/src/events/device_event.rs
@@ -9,7 +9,7 @@ use crate::{DeviceRef, DeviceStatus};
 #[doc = " device is detected. You can use the handle provided by the device filed to"]
 #[doc = " open a device so that you can access its properties."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct DeviceEventRef<'a>(pub(crate) &'a LEAP_DEVICE_EVENT);
 
 impl<'a> DeviceEventRef<'a> {

--- a/src/events/device_event.rs
+++ b/src/events/device_event.rs
@@ -10,9 +10,9 @@ use crate::{DeviceRef, DeviceStatus};
 #[doc = " open a device so that you can access its properties."]
 #[doc = " @since 3.0.0"]
 #[derive(Deref)]
-pub struct DeviceEvent<'a>(pub(crate) &'a LEAP_DEVICE_EVENT);
+pub struct DeviceEventRef<'a>(pub(crate) &'a LEAP_DEVICE_EVENT);
 
-impl<'a> DeviceEvent<'a> {
+impl<'a> DeviceEventRef<'a> {
     #[doc = " The handle reference of to the newly attached device. @since 3.0.0"]
     pub fn device(&self) -> DeviceRef {
         DeviceRef(self.device)

--- a/src/events/device_failure_event.rs
+++ b/src/events/device_failure_event.rs
@@ -10,9 +10,9 @@ use crate::{Device, DeviceStatus};
 #[doc = " open device."]
 #[doc = " @since 3.0.0"]
 #[derive(Deref)]
-pub struct DeviceFailureEvent<'a>(pub(crate) &'a LEAP_DEVICE_FAILURE_EVENT);
+pub struct DeviceFailureEventRef<'a>(pub(crate) &'a LEAP_DEVICE_FAILURE_EVENT);
 
-impl<'a> DeviceFailureEvent<'a> {
+impl<'a> DeviceFailureEventRef<'a> {
     #[doc = " The status of this failure event. @since 3.0.0"]
     pub fn status(&self) -> DeviceStatus {
         DeviceStatus::from_bits_truncate(self.status as u32)

--- a/src/events/device_failure_event.rs
+++ b/src/events/device_failure_event.rs
@@ -9,7 +9,7 @@ use crate::{Device, DeviceStatus};
 #[doc = " non-null, then you can use it to identify the failed device with a known,"]
 #[doc = " open device."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct DeviceFailureEventRef<'a>(pub(crate) &'a LEAP_DEVICE_FAILURE_EVENT);
 
 impl<'a> DeviceFailureEventRef<'a> {

--- a/src/events/device_status_change_event.rs
+++ b/src/events/device_status_change_event.rs
@@ -6,7 +6,7 @@ use crate::{DeviceRef, DeviceStatus};
 #[doc = " A notification that a device's status has changed. One of these messages is received by the client"]
 #[doc = " as soon as the service is connected, or when a new device is attached."]
 #[doc = " @since 3.1.3"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct DeviceStatusChangeEventRef<'a>(pub(crate) &'a LEAP_DEVICE_STATUS_CHANGE_EVENT);
 
 impl<'a> DeviceStatusChangeEventRef<'a> {

--- a/src/events/device_status_change_event.rs
+++ b/src/events/device_status_change_event.rs
@@ -7,9 +7,9 @@ use crate::{DeviceRef, DeviceStatus};
 #[doc = " as soon as the service is connected, or when a new device is attached."]
 #[doc = " @since 3.1.3"]
 #[derive(Deref)]
-pub struct DeviceStatusChangeEvent<'a>(pub(crate) &'a LEAP_DEVICE_STATUS_CHANGE_EVENT);
+pub struct DeviceStatusChangeEventRef<'a>(pub(crate) &'a LEAP_DEVICE_STATUS_CHANGE_EVENT);
 
-impl<'a> DeviceStatusChangeEvent<'a> {
+impl<'a> DeviceStatusChangeEventRef<'a> {
     #[doc = " A reference to the device whose status has changed"]
     pub fn device(&self) -> DeviceRef {
         DeviceRef(self.device)

--- a/src/events/dropped_frame_event.rs
+++ b/src/events/dropped_frame_event.rs
@@ -3,7 +3,7 @@ use leap_sys::LEAP_DROPPED_FRAME_EVENT;
 
 use crate::DroppedFrameType;
 
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct DroppedFrameEventRef<'a>(pub(crate) &'a LEAP_DROPPED_FRAME_EVENT);
 
 impl<'a> DroppedFrameEventRef<'a> {

--- a/src/events/dropped_frame_event.rs
+++ b/src/events/dropped_frame_event.rs
@@ -4,9 +4,9 @@ use leap_sys::LEAP_DROPPED_FRAME_EVENT;
 use crate::DroppedFrameType;
 
 #[derive(Deref)]
-pub struct DroppedFrameEvent<'a>(pub(crate) &'a LEAP_DROPPED_FRAME_EVENT);
+pub struct DroppedFrameEventRef<'a>(pub(crate) &'a LEAP_DROPPED_FRAME_EVENT);
 
-impl<'a> DroppedFrameEvent<'a> {
+impl<'a> DroppedFrameEventRef<'a> {
     pub fn dropped_frame_type(&self) -> DroppedFrameType {
         self.type_.into()
     }

--- a/src/events/eye_event.rs
+++ b/src/events/eye_event.rs
@@ -1,21 +1,21 @@
 use derive_deref::Deref;
 use leap_sys::LEAP_EYE_EVENT;
 
-use crate::LeapVector;
+use crate::LeapVectorRef;
 
 #[derive(Deref)]
-pub struct EyeEvent<'a>(pub(crate) &'a LEAP_EYE_EVENT);
+pub struct EyeEventRef<'a>(pub(crate) &'a LEAP_EYE_EVENT);
 
-impl<'a> EyeEvent<'a> {
+impl<'a> EyeEventRef<'a> {
     #[doc = " The position of the user's left eye."]
     #[doc = " @since 4.1.0"]
-    pub fn left_eye_position(&self) -> LeapVector {
-        LeapVector::from(&self.left_eye_position)
+    pub fn left_eye_position(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.left_eye_position)
     }
 
     #[doc = " The position of the user's right eye."]
     #[doc = " @since 4.1.0"]
-    pub fn right_eye_position(&self) -> LeapVector {
-        LeapVector::from(&self.right_eye_position)
+    pub fn right_eye_position(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.right_eye_position)
     }
 }

--- a/src/events/eye_event.rs
+++ b/src/events/eye_event.rs
@@ -3,7 +3,7 @@ use leap_sys::LEAP_EYE_EVENT;
 
 use crate::LeapVectorRef;
 
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct EyeEventRef<'a>(pub(crate) &'a LEAP_EYE_EVENT);
 
 impl<'a> EyeEventRef<'a> {

--- a/src/events/head_pose_event.rs
+++ b/src/events/head_pose_event.rs
@@ -3,7 +3,7 @@ use leap_sys::LEAP_HEAD_POSE_EVENT;
 
 use crate::{LeapVectorRef, QuaternionRef};
 
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct HeadPoseEventRef<'a>(pub(crate) &'a LEAP_HEAD_POSE_EVENT);
 
 impl<'a> HeadPoseEventRef<'a> {

--- a/src/events/head_pose_event.rs
+++ b/src/events/head_pose_event.rs
@@ -1,29 +1,29 @@
 use derive_deref::Deref;
 use leap_sys::LEAP_HEAD_POSE_EVENT;
 
-use crate::{LeapVector, Quaternion};
+use crate::{LeapVectorRef, QuaternionRef};
 
 #[derive(Deref)]
-pub struct HeadPoseEvent<'a>(pub(crate) &'a LEAP_HEAD_POSE_EVENT);
+pub struct HeadPoseEventRef<'a>(pub(crate) &'a LEAP_HEAD_POSE_EVENT);
 
-impl<'a> HeadPoseEvent<'a> {
+impl<'a> HeadPoseEventRef<'a> {
     #[doc = " The position and orientation of the user's head. Positional tracking must be enabled."]
     #[doc = " @since 4.1.0"]
-    pub fn head_position(&self) -> LeapVector {
-        LeapVector::from(&self.head_position)
+    pub fn head_position(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.head_position)
     }
 
-    pub fn head_orientation(&self) -> Quaternion {
-        Quaternion::from(&self.head_orientation)
+    pub fn head_orientation(&self) -> QuaternionRef {
+        QuaternionRef::from(&self.head_orientation)
     }
 
     #[doc = " The linear and angular velocity of the user's head. Positional tracking must be enabled."]
     #[doc = " @since 4.1.0"]
-    pub fn head_linear_velocity(&self) -> LeapVector {
-        LeapVector::from(&self.head_linear_velocity)
+    pub fn head_linear_velocity(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.head_linear_velocity)
     }
 
-    pub fn head_angular_velocity(&self) -> LeapVector {
-        LeapVector::from(&self.head_angular_velocity)
+    pub fn head_angular_velocity(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.head_angular_velocity)
     }
 }

--- a/src/events/image_event.rs
+++ b/src/events/image_event.rs
@@ -1,4 +1,4 @@
-use crate::{FrameHeader, Image};
+use crate::{FrameHeaderRef, ImageRef};
 use derive_deref::Deref;
 use leap_sys::LEAP_IMAGE_EVENT;
 
@@ -10,17 +10,17 @@ use leap_sys::LEAP_IMAGE_EVENT;
 #[doc = " function passed to LeapC using the LeapSetAllocator."]
 #[doc = " @since 4.0.0"]
 #[derive(Deref)]
-pub struct ImageEvent<'a>(pub(crate) &'a LEAP_IMAGE_EVENT);
+pub struct ImageEventRef<'a>(pub(crate) &'a LEAP_IMAGE_EVENT);
 
-impl<'a> ImageEvent<'a> {
+impl<'a> ImageEventRef<'a> {
     #[doc = " The information header identifying the images tracking frame."]
-    pub fn info(&self) -> FrameHeader {
-        FrameHeader(&self.info)
+    pub fn info(&self) -> FrameHeaderRef {
+        FrameHeaderRef(&self.info)
     }
 
     #[doc = " The left and right images."]
-    pub fn images(&self) -> [Image; 2] {
-        [(Image(&self.image[0])), (Image(&self.image[1]))]
+    pub fn images(&self) -> [ImageRef; 2] {
+        [(ImageRef(&self.image[0])), (ImageRef(&self.image[1]))]
     }
 }
 
@@ -38,7 +38,7 @@ mod tests {
 
         let (width, height, data, _frame_id) = connection
             .wait_for(|e| match e {
-                Event::Image(e) => {
+                EventRef::Image(e) => {
                     let right_image = &e.images()[1];
                     let data = right_image.data();
                     let width = right_image.properties().width;

--- a/src/events/image_event.rs
+++ b/src/events/image_event.rs
@@ -9,7 +9,7 @@ use leap_sys::LEAP_IMAGE_EVENT;
 #[doc = " the buffer containing the image data -- which was allocated using the allocator"]
 #[doc = " function passed to LeapC using the LeapSetAllocator."]
 #[doc = " @since 4.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct ImageEventRef<'a>(pub(crate) &'a LEAP_IMAGE_EVENT);
 
 impl<'a> ImageEventRef<'a> {

--- a/src/events/imu_event.rs
+++ b/src/events/imu_event.rs
@@ -1,12 +1,12 @@
 use derive_deref::Deref;
 use leap_sys::LEAP_IMU_EVENT;
 
-use crate::{ImuFlag, LeapVector};
+use crate::{ImuFlag, LeapVectorRef};
 
 #[derive(Deref)]
-pub struct ImuEvent<'a>(pub(crate) &'a LEAP_IMU_EVENT);
+pub struct ImuEventRef<'a>(pub(crate) &'a LEAP_IMU_EVENT);
 
-impl<'a> ImuEvent<'a> {
+impl<'a> ImuEventRef<'a> {
     #[doc = " A combination of eLeapIMUFlag flags."]
     #[doc = " @since 4.1.0"]
     pub fn flags(&self) -> ImuFlag {
@@ -15,13 +15,13 @@ impl<'a> ImuEvent<'a> {
 
     #[doc = " The accelerometer measurements, in m/s^2."]
     #[doc = " @since 4.1.0"]
-    pub fn accelerometer(&self) -> LeapVector {
-        LeapVector::from(&self.accelerometer)
+    pub fn accelerometer(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.accelerometer)
     }
 
     #[doc = " The gyroscope measurements, in rad/s."]
     #[doc = " @since 4.1.0"]
-    pub fn gyroscope(&self) -> LeapVector {
-        LeapVector::from(&self.gyroscope)
+    pub fn gyroscope(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.gyroscope)
     }
 }

--- a/src/events/imu_event.rs
+++ b/src/events/imu_event.rs
@@ -3,7 +3,7 @@ use leap_sys::LEAP_IMU_EVENT;
 
 use crate::{ImuFlag, LeapVectorRef};
 
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct ImuEventRef<'a>(pub(crate) &'a LEAP_IMU_EVENT);
 
 impl<'a> ImuEventRef<'a> {

--- a/src/events/interpolation_tracking_event.rs
+++ b/src/events/interpolation_tracking_event.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::{sized_with_trailing_data::SizedWithTrailingData, FrameHeader, Hand};
+use crate::{sized_with_trailing_data::SizedWithTrailingData, FrameHeaderRef, HandRef};
 use leap_sys::LEAP_TRACKING_EVENT;
 
 pub struct InterpolationTrackingEvent(pub(crate) Box<SizedWithTrailingData<LEAP_TRACKING_EVENT>>);
@@ -18,18 +18,18 @@ impl InterpolationTrackingEvent {
     }
 
     #[doc = " A universal frame identification header. @since 3.0.0"]
-    pub fn info(&self) -> FrameHeader {
-        FrameHeader(&self.info)
+    pub fn info(&self) -> FrameHeaderRef {
+        FrameHeaderRef(&self.info)
     }
 
     #[doc = " A pointer to the array of hands tracked in this frame."]
     #[doc = " @since 3.0.0"]
-    pub fn hands(&self) -> Vec<Hand> {
+    pub fn hands(&self) -> Vec<HandRef> {
         let n_hand = self.nHands as isize;
         unsafe {
             (0..n_hand)
                 .map(|hand_index| &*self.pHands.offset(hand_index))
-                .map(Hand)
+                .map(HandRef)
                 .collect()
         }
     }

--- a/src/events/log_event.rs
+++ b/src/events/log_event.rs
@@ -7,9 +7,9 @@ use crate::LogSeverity;
 
 #[doc = " A system log message. @since 3.0.0"]
 #[derive(Deref)]
-pub struct LogEvent<'a>(pub(crate) &'a LEAP_LOG_EVENT);
+pub struct LogEventRef<'a>(pub(crate) &'a LEAP_LOG_EVENT);
 
-impl<'a> LogEvent<'a> {
+impl<'a> LogEventRef<'a> {
     #[doc = " The type of message. @since 4.0.0"]
     pub fn severity(&self) -> LogSeverity {
         self.severity.into()

--- a/src/events/log_event.rs
+++ b/src/events/log_event.rs
@@ -6,7 +6,7 @@ use leap_sys::LEAP_LOG_EVENT;
 use crate::LogSeverity;
 
 #[doc = " A system log message. @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct LogEventRef<'a>(pub(crate) &'a LEAP_LOG_EVENT);
 
 impl<'a> LogEventRef<'a> {

--- a/src/events/log_events.rs
+++ b/src/events/log_events.rs
@@ -1,23 +1,23 @@
 use derive_deref::Deref;
 use leap_sys::LEAP_LOG_EVENTS;
 
-use crate::LogEvent;
+use crate::LogEventRef;
 
 #[doc = " A notification that a device's status has changed. One of these messages is received by the client"]
 #[doc = " as soon as the service is connected, or when a new device is attached."]
 #[doc = " @since 3.1.3"]
 #[derive(Deref)]
-pub struct LogEvents<'a>(pub(crate) &'a LEAP_LOG_EVENTS);
+pub struct LogEventsRef<'a>(pub(crate) &'a LEAP_LOG_EVENTS);
 
-impl<'a> LogEvents<'a> {
+impl<'a> LogEventsRef<'a> {
     #[doc = " An array of ``nEvent`` LEAP_LOG_EVENT structures."]
     #[doc = " @since 4.0.0"]
-    pub fn events(&self) -> Vec<LogEvent> {
+    pub fn events(&self) -> Vec<LogEventRef> {
         let events;
         unsafe {
             events = (0..self.nEvents)
                 .map(|index| (&*self.events.add(index as usize)))
-                .map(LogEvent);
+                .map(LogEventRef);
         }
         events.collect()
     }

--- a/src/events/log_events.rs
+++ b/src/events/log_events.rs
@@ -6,7 +6,7 @@ use crate::LogEventRef;
 #[doc = " A notification that a device's status has changed. One of these messages is received by the client"]
 #[doc = " as soon as the service is connected, or when a new device is attached."]
 #[doc = " @since 3.1.3"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct LogEventsRef<'a>(pub(crate) &'a LEAP_LOG_EVENTS);
 
 impl<'a> LogEventsRef<'a> {

--- a/src/events/point_mapping_change_event.rs
+++ b/src/events/point_mapping_change_event.rs
@@ -2,4 +2,4 @@ use derive_deref::Deref;
 use leap_sys::LEAP_POINT_MAPPING_CHANGE_EVENT;
 
 #[derive(Deref)]
-pub struct PointMappingChangeEvent<'a>(pub(crate) &'a LEAP_POINT_MAPPING_CHANGE_EVENT);
+pub struct PointMappingChangeEventRef<'a>(pub(crate) &'a LEAP_POINT_MAPPING_CHANGE_EVENT);

--- a/src/events/point_mapping_change_event.rs
+++ b/src/events/point_mapping_change_event.rs
@@ -1,5 +1,5 @@
 use derive_deref::Deref;
 use leap_sys::LEAP_POINT_MAPPING_CHANGE_EVENT;
 
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct PointMappingChangeEventRef<'a>(pub(crate) &'a LEAP_POINT_MAPPING_CHANGE_EVENT);

--- a/src/events/policy_event.rs
+++ b/src/events/policy_event.rs
@@ -7,9 +7,9 @@ use crate::PolicyFlags;
 #[doc = " LeapPollConnection() creates this struct when the response becomes available."]
 #[doc = " @since 3.0.0"]
 #[derive(Deref)]
-pub struct PolicyEvent<'a>(pub(crate) &'a LEAP_POLICY_EVENT);
+pub struct PolicyEventRef<'a>(pub(crate) &'a LEAP_POLICY_EVENT);
 
-impl<'a> PolicyEvent<'a> {
+impl<'a> PolicyEventRef<'a> {
     #[doc = " A bitfield containing the policies effective at the"]
     #[doc = " time the policy event was processed. @since 3.0.0"]
     pub fn current_policy(&self) -> PolicyFlags {
@@ -29,7 +29,7 @@ mod tests {
             .expect("Failed to set policy");
         connection
             .wait_for(|e| match e {
-                Event::Policy(e) => {
+                EventRef::Policy(e) => {
                     if e.current_policy().contains(PolicyFlags::IMAGES) {
                         Some(())
                     } else {

--- a/src/events/policy_event.rs
+++ b/src/events/policy_event.rs
@@ -6,7 +6,7 @@ use crate::PolicyFlags;
 #[doc = " The response from a request to get or set a policy."]
 #[doc = " LeapPollConnection() creates this struct when the response becomes available."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct PolicyEventRef<'a>(pub(crate) &'a LEAP_POLICY_EVENT);
 
 impl<'a> PolicyEventRef<'a> {

--- a/src/events/tracking_event.rs
+++ b/src/events/tracking_event.rs
@@ -6,7 +6,7 @@ use crate::{FrameHeaderRef, HandRef};
 #[doc = " A snapshot, or frame of data, containing the tracking data for a single moment in time."]
 #[doc = " The LEAP_FRAME struct is the container for all the tracking data."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct TrackingEventRef<'a>(pub(crate) &'a LEAP_TRACKING_EVENT);
 
 impl<'a> TrackingEventRef<'a> {

--- a/src/events/tracking_event.rs
+++ b/src/events/tracking_event.rs
@@ -1,28 +1,28 @@
 use derive_deref::Deref;
 use leap_sys::LEAP_TRACKING_EVENT;
 
-use crate::{FrameHeader, Hand};
+use crate::{FrameHeaderRef, HandRef};
 
 #[doc = " A snapshot, or frame of data, containing the tracking data for a single moment in time."]
 #[doc = " The LEAP_FRAME struct is the container for all the tracking data."]
 #[doc = " @since 3.0.0"]
 #[derive(Deref)]
-pub struct TrackingEvent<'a>(pub(crate) &'a LEAP_TRACKING_EVENT);
+pub struct TrackingEventRef<'a>(pub(crate) &'a LEAP_TRACKING_EVENT);
 
-impl<'a> TrackingEvent<'a> {
+impl<'a> TrackingEventRef<'a> {
     #[doc = " A universal frame identification header. @since 3.0.0"]
-    pub fn info(&self) -> FrameHeader {
-        FrameHeader(&self.info)
+    pub fn info(&self) -> FrameHeaderRef {
+        FrameHeaderRef(&self.info)
     }
 
     #[doc = " A pointer to the array of hands tracked in this frame."]
     #[doc = " @since 3.0.0"]
-    pub fn hands(&self) -> Vec<Hand> {
+    pub fn hands(&self) -> Vec<HandRef> {
         let n_hand = self.nHands as isize;
         unsafe {
             (0..n_hand)
                 .map(|hand_index| &*self.pHands.offset(hand_index))
-                .map(Hand)
+                .map(HandRef)
                 .collect()
         }
     }
@@ -37,7 +37,7 @@ mod tests {
     fn read_hands() {
         let mut conn = initialize_connection();
         conn.wait_for(|e| match e {
-            Event::Tracking(e) => {
+            EventRef::Tracking(e) => {
                 let hands = e.hands();
                 let hand_ids: Vec<_> = hands.iter().map(|h| h.id).collect();
                 Some(hand_ids)

--- a/src/events/tracking_mode_event.rs
+++ b/src/events/tracking_mode_event.rs
@@ -6,7 +6,7 @@ use crate::TrackingMode;
 #[doc = " The response from a request to get or set a policy."]
 #[doc = " LeapPollConnection() creates this struct when the response becomes available."]
 #[doc = " @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct TrackingModeEventRef<'a>(pub(crate) &'a LEAP_TRACKING_MODE_EVENT);
 
 impl<'a> TrackingModeEventRef<'a> {

--- a/src/events/tracking_mode_event.rs
+++ b/src/events/tracking_mode_event.rs
@@ -7,9 +7,9 @@ use crate::TrackingMode;
 #[doc = " LeapPollConnection() creates this struct when the response becomes available."]
 #[doc = " @since 3.0.0"]
 #[derive(Deref)]
-pub struct TrackingModeEvent<'a>(pub(crate) &'a LEAP_TRACKING_MODE_EVENT);
+pub struct TrackingModeEventRef<'a>(pub(crate) &'a LEAP_TRACKING_MODE_EVENT);
 
-impl<'a> TrackingModeEvent<'a> {
+impl<'a> TrackingModeEventRef<'a> {
     #[doc = " An enum specifying the tracking mode effective at the"]
     #[doc = " time the tracking mode event was processed. @since 5.0.0"]
     pub fn current_tracking_mode(&self) -> TrackingMode {
@@ -29,7 +29,7 @@ mod tests {
 
         let mode = connection
             .wait_for(|e| match e {
-                Event::TrackingMode(mode) => Some(mode.current_tracking_mode()),
+                EventRef::TrackingMode(mode) => Some(mode.current_tracking_mode()),
                 _ => None,
             })
             .expect("Did not receive the tracking mode");
@@ -45,7 +45,7 @@ mod tests {
 
         let mode = connection
             .wait_for(|e| match e {
-                Event::TrackingMode(mode) => Some(mode.current_tracking_mode()),
+                EventRef::TrackingMode(mode) => Some(mode.current_tracking_mode()),
                 _ => None,
             })
             .expect("Did not receive the tracking mode");

--- a/src/frame_header.rs
+++ b/src/frame_header.rs
@@ -3,4 +3,4 @@ use leap_sys::LEAP_FRAME_HEADER;
 
 #[doc = " Identifying information for a frame of tracking data. @since 3.0.0"]
 #[derive(Deref)]
-pub struct FrameHeader<'a>(pub(crate) &'a LEAP_FRAME_HEADER);
+pub struct FrameHeaderRef<'a>(pub(crate) &'a LEAP_FRAME_HEADER);

--- a/src/frame_header.rs
+++ b/src/frame_header.rs
@@ -2,5 +2,5 @@ use derive_deref::Deref;
 use leap_sys::LEAP_FRAME_HEADER;
 
 #[doc = " Identifying information for a frame of tracking data. @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct FrameHeaderRef<'a>(pub(crate) &'a LEAP_FRAME_HEADER);

--- a/src/hand.rs
+++ b/src/hand.rs
@@ -15,7 +15,7 @@ pub enum HandType {
 }
 
 #[doc = " Describes a tracked hand. @since 3.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct HandRef<'a>(pub(crate) &'a LEAP_HAND);
 
 impl<'a> HandRef<'a> {

--- a/src/hand.rs
+++ b/src/hand.rs
@@ -1,7 +1,7 @@
 use derive_deref::Deref;
 use leap_sys::*;
 
-use crate::{Bone, Digit, Palm};
+use crate::{BoneRef, DigitRef, PalmRef};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[doc = " The Hand chirality types."]
@@ -16,9 +16,9 @@ pub enum HandType {
 
 #[doc = " Describes a tracked hand. @since 3.0.0"]
 #[derive(Deref)]
-pub struct Hand<'a>(pub(crate) &'a LEAP_HAND);
+pub struct HandRef<'a>(pub(crate) &'a LEAP_HAND);
 
-impl<'a> Hand<'a> {
+impl<'a> HandRef<'a> {
     #[doc = " Identifies the chirality of this hand. @since 3.0.0"]
     pub fn hand_type(&self) -> HandType {
         match self.type_ {
@@ -29,55 +29,55 @@ impl<'a> Hand<'a> {
     }
 
     #[doc = " Additional information associated with the palm. @since 3.0.0"]
-    pub fn palm(&self) -> Palm {
-        Palm(&self.palm)
+    pub fn palm(&self) -> PalmRef {
+        PalmRef(&self.palm)
     }
 
     #[doc = " The arm to which this hand is attached."]
     #[doc = " An arm consists of a single LEAP_BONE struct."]
     #[doc = " @since 3.0.0"]
-    pub fn arm(&self) -> Bone {
-        Bone(&self.arm)
+    pub fn arm(&self) -> BoneRef {
+        BoneRef(&self.arm)
     }
 
     #[doc = " The fingers of the hand as an array. @since 3.0.0"]
-    pub fn digits(&self) -> [Digit; 5] {
+    pub fn digits(&self) -> [DigitRef; 5] {
         let digits;
         unsafe {
             digits = &self.__bindgen_anon_1.digits;
         }
         [
-            Digit(&digits[0]),
-            Digit(&digits[1]),
-            Digit(&digits[2]),
-            Digit(&digits[3]),
-            Digit(&digits[4]),
+            DigitRef(&digits[0]),
+            DigitRef(&digits[1]),
+            DigitRef(&digits[2]),
+            DigitRef(&digits[3]),
+            DigitRef(&digits[4]),
         ]
     }
 
     #[doc = " The thumb. @since 3.0.0"]
-    pub fn thumb(&self) -> Digit {
-        unsafe { Digit(&self.__bindgen_anon_1.__bindgen_anon_1.thumb) }
+    pub fn thumb(&self) -> DigitRef {
+        unsafe { DigitRef(&self.__bindgen_anon_1.__bindgen_anon_1.thumb) }
     }
 
     #[doc = " The index finger. @since 3.0.0"]
-    pub fn index(&self) -> Digit {
-        unsafe { Digit(&self.__bindgen_anon_1.__bindgen_anon_1.index) }
+    pub fn index(&self) -> DigitRef {
+        unsafe { DigitRef(&self.__bindgen_anon_1.__bindgen_anon_1.index) }
     }
 
     #[doc = " The middle finger. @since 3.0.0"]
-    pub fn middle(&self) -> Digit {
-        unsafe { Digit(&self.__bindgen_anon_1.__bindgen_anon_1.middle) }
+    pub fn middle(&self) -> DigitRef {
+        unsafe { DigitRef(&self.__bindgen_anon_1.__bindgen_anon_1.middle) }
     }
 
     #[doc = " The ring finger. @since 3.0.0"]
-    pub fn ring(&self) -> Digit {
-        unsafe { Digit(&self.__bindgen_anon_1.__bindgen_anon_1.ring) }
+    pub fn ring(&self) -> DigitRef {
+        unsafe { DigitRef(&self.__bindgen_anon_1.__bindgen_anon_1.ring) }
     }
 
     #[doc = " The pinky finger. @since 3.0.0"]
-    pub fn pinky(&self) -> Digit {
-        unsafe { Digit(&self.__bindgen_anon_1.__bindgen_anon_1.pinky) }
+    pub fn pinky(&self) -> DigitRef {
+        unsafe { DigitRef(&self.__bindgen_anon_1.__bindgen_anon_1.pinky) }
     }
 }
 
@@ -91,7 +91,7 @@ mod tests {
         let mut connection = initialize_connection();
         connection
             .wait_for(|e| match e {
-                Event::Tracking(e) => {
+                EventRef::Tracking(e) => {
                     let hands = e.hands();
                     if hands.is_empty() {
                         println!("Warning: Put hands in front of the sensor for this test.");

--- a/src/image.rs
+++ b/src/image.rs
@@ -5,7 +5,7 @@ use crate::{DistortionMatrixRef, ImagePropertiesRef};
 
 #[doc = " An image associated with a frame of data."]
 #[doc = " @since 4.0.0"]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct ImageRef<'a>(pub(crate) &'a LEAP_IMAGE);
 
 impl<'a> ImageRef<'a> {

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,28 +1,28 @@
 use derive_deref::Deref;
 use leap_sys::LEAP_IMAGE;
 
-use crate::{DistortionMatrix, ImageProperties};
+use crate::{DistortionMatrixRef, ImagePropertiesRef};
 
 #[doc = " An image associated with a frame of data."]
 #[doc = " @since 4.0.0"]
 #[derive(Deref)]
-pub struct Image<'a>(pub(crate) &'a LEAP_IMAGE);
+pub struct ImageRef<'a>(pub(crate) &'a LEAP_IMAGE);
 
-impl<'a> Image<'a> {
+impl<'a> ImageRef<'a> {
     #[doc = " The properties of the received image."]
-    pub fn properties(&self) -> ImageProperties {
-        ImageProperties(&self.properties)
+    pub fn properties(&self) -> ImagePropertiesRef {
+        ImagePropertiesRef(&self.properties)
     }
 
     #[doc = " Pointers to the camera's distortion matrix."]
-    pub fn distorion_matrix(&self) -> DistortionMatrix {
+    pub fn distorion_matrix(&self) -> DistortionMatrixRef {
         let distortion_matrix;
 
         unsafe {
             distortion_matrix = &*self.distortion_matrix;
         }
 
-        DistortionMatrix(distortion_matrix)
+        DistortionMatrixRef(distortion_matrix)
     }
 
     #[doc = " A pointer to the image data."]

--- a/src/image_properties.rs
+++ b/src/image_properties.rs
@@ -4,7 +4,7 @@ use leap_sys::LEAP_IMAGE_PROPERTIES;
 use crate::{ImageFormat, ImageType};
 
 #[doc = " Properties of a sensor image."]
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct ImagePropertiesRef<'a>(pub(crate) &'a LEAP_IMAGE_PROPERTIES);
 
 impl<'a> ImagePropertiesRef<'a> {

--- a/src/image_properties.rs
+++ b/src/image_properties.rs
@@ -5,9 +5,9 @@ use crate::{ImageFormat, ImageType};
 
 #[doc = " Properties of a sensor image."]
 #[derive(Deref)]
-pub struct ImageProperties<'a>(pub(crate) &'a LEAP_IMAGE_PROPERTIES);
+pub struct ImagePropertiesRef<'a>(pub(crate) &'a LEAP_IMAGE_PROPERTIES);
 
-impl<'a> ImageProperties<'a> {
+impl<'a> ImagePropertiesRef<'a> {
     #[doc = " The type of this image. @since 3.0.0"]
     pub fn image_type(&self) -> ImageType {
         self.type_.into()

--- a/src/leap_vector.rs
+++ b/src/leap_vector.rs
@@ -4,15 +4,15 @@ use leap_sys::{_LEAP_VECTOR__bindgen_ty_1, _LEAP_VECTOR__bindgen_ty_1__bindgen_t
 
 #[doc = " A three element, floating-point vector."]
 #[doc = " @since 3.0.0"]
-pub struct LeapVector<'a>(pub(crate) &'a _LEAP_VECTOR__bindgen_ty_1);
+pub struct LeapVectorRef<'a>(pub(crate) &'a _LEAP_VECTOR__bindgen_ty_1);
 
-impl<'a> From<&'a LEAP_VECTOR> for LeapVector<'a> {
+impl<'a> From<&'a LEAP_VECTOR> for LeapVectorRef<'a> {
     fn from(vector: &'a LEAP_VECTOR) -> Self {
         Self(&vector.__bindgen_anon_1)
     }
 }
 
-impl<'a> LeapVector<'a> {
+impl<'a> LeapVectorRef<'a> {
     pub fn array(&self) -> [f32; 3] {
         unsafe { self.0.v }
     }
@@ -30,7 +30,7 @@ impl<'a> LeapVector<'a> {
     }
 }
 
-impl<'a> Deref for LeapVector<'a> {
+impl<'a> Deref for LeapVectorRef<'a> {
     type Target = _LEAP_VECTOR__bindgen_ty_1__bindgen_ty_1;
 
     fn deref(&self) -> &Self::Target {
@@ -39,15 +39,15 @@ impl<'a> Deref for LeapVector<'a> {
 }
 
 #[cfg(feature = "glam")]
-impl From<LeapVector<'_>> for glam::Vec3 {
-    fn from(v: LeapVector) -> glam::Vec3 {
+impl From<LeapVectorRef<'_>> for glam::Vec3 {
+    fn from(v: LeapVectorRef) -> glam::Vec3 {
         v.into_glam()
     }
 }
 
 #[cfg(feature = "nalgebra")]
-impl From<LeapVector<'_>> for nalgebra::Vector3<f32> {
-    fn from(v: LeapVector) -> nalgebra::Vector3<f32> {
+impl From<LeapVectorRef<'_>> for nalgebra::Vector3<f32> {
+    fn from(v: LeapVectorRef) -> nalgebra::Vector3<f32> {
         v.into_nalgebra()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,14 +108,14 @@ mod tests {
 
         connection
             .wait_for(|e| match e {
-                Event::Connection(_) => Some(()),
+                EventRef::Connection(_) => Some(()),
                 _ => None,
             })
             .expect("Did not receive connection message");
 
         connection
             .wait_for(|e| match e {
-                Event::Device(_) => Some(()),
+                EventRef::Device(_) => Some(()),
                 _ => None,
             })
             .expect("Did not receive device connection");
@@ -146,13 +146,13 @@ mod tests {
     pub trait ConnectionTestExtensions {
         fn wait_for<F, T>(&mut self, condition: F) -> Result<T, &str>
         where
-            F: Fn(&Event) -> Option<T>;
+            F: Fn(&EventRef) -> Option<T>;
     }
 
     impl ConnectionTestExtensions for Connection {
         fn wait_for<F, T>(&mut self, condition: F) -> Result<T, &str>
         where
-            F: Fn(&Event) -> Option<T>,
+            F: Fn(&EventRef) -> Option<T>,
         {
             for _ in 0..200 {
                 if let Ok(event_message) = self.poll(100) {

--- a/src/palm.rs
+++ b/src/palm.rs
@@ -1,33 +1,33 @@
 use derive_deref::Deref;
 use leap_sys::LEAP_PALM;
 
-use crate::{LeapVector, Quaternion};
+use crate::{LeapVectorRef, QuaternionRef};
 
 #[derive(Deref)]
-pub struct Palm<'a>(pub(crate) &'a LEAP_PALM);
+pub struct PalmRef<'a>(pub(crate) &'a LEAP_PALM);
 
-impl<'a> Palm<'a> {
-    pub fn position(&self) -> LeapVector {
-        LeapVector::from(&self.position)
+impl<'a> PalmRef<'a> {
+    pub fn position(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.position)
     }
 
-    pub fn stabilized_position(&self) -> LeapVector {
-        LeapVector::from(&self.stabilized_position)
+    pub fn stabilized_position(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.stabilized_position)
     }
 
-    pub fn velocity(&self) -> LeapVector {
-        LeapVector::from(&self.velocity)
+    pub fn velocity(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.velocity)
     }
 
-    pub fn normal(&self) -> LeapVector {
-        LeapVector::from(&self.normal)
+    pub fn normal(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.normal)
     }
 
-    pub fn orientation(&self) -> Quaternion {
-        Quaternion::from(&self.orientation)
+    pub fn orientation(&self) -> QuaternionRef {
+        QuaternionRef::from(&self.orientation)
     }
 
-    pub fn direction(&self) -> LeapVector {
-        LeapVector::from(&self.direction)
+    pub fn direction(&self) -> LeapVectorRef {
+        LeapVectorRef::from(&self.direction)
     }
 }

--- a/src/palm.rs
+++ b/src/palm.rs
@@ -3,7 +3,7 @@ use leap_sys::LEAP_PALM;
 
 use crate::{LeapVectorRef, QuaternionRef};
 
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct PalmRef<'a>(pub(crate) &'a LEAP_PALM);
 
 impl<'a> PalmRef<'a> {

--- a/src/point_mapping.rs
+++ b/src/point_mapping.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use leap_sys::LEAP_POINT_MAPPING;
 
-use crate::{sized_with_trailing_data::SizedWithTrailingData, LeapVector};
+use crate::{sized_with_trailing_data::SizedWithTrailingData, LeapVectorRef};
 
 pub struct PointMapping {
     /// Store a boxed dynamic sized event
@@ -29,10 +29,10 @@ impl PointMapping {
     }
 
     #[doc = " The 3D points being mapped. @since 4.0.0"]
-    pub fn points(&self) -> Vec<LeapVector> {
+    pub fn points(&self) -> Vec<LeapVectorRef> {
         unsafe {
             (0..self.handle.sized.nPoints as isize)
-                .map(|i| LeapVector::from(&*self.handle.sized.pPoints.offset(i)))
+                .map(|i| LeapVectorRef::from(&*self.handle.sized.pPoints.offset(i)))
                 .collect()
         }
     }

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -3,15 +3,15 @@ use leap_sys::{
 };
 
 #[doc = " A four element, floating point quaternion. @since 3.1.2"]
-pub struct Quaternion<'a>(pub(crate) &'a _LEAP_QUATERNION__bindgen_ty_1);
+pub struct QuaternionRef<'a>(pub(crate) &'a _LEAP_QUATERNION__bindgen_ty_1);
 
-impl<'a> From<&'a LEAP_QUATERNION> for Quaternion<'a> {
+impl<'a> From<&'a LEAP_QUATERNION> for QuaternionRef<'a> {
     fn from(quaternion: &'a LEAP_QUATERNION) -> Self {
         Self(&quaternion.__bindgen_anon_1)
     }
 }
 
-impl<'a> Quaternion<'a> {
+impl<'a> QuaternionRef<'a> {
     pub fn array(&self) -> [f32; 4] {
         unsafe { self.0.v }
     }
@@ -31,7 +31,7 @@ impl<'a> Quaternion<'a> {
     }
 }
 
-impl<'a> core::ops::Deref for Quaternion<'a> {
+impl<'a> core::ops::Deref for QuaternionRef<'a> {
     type Target = _LEAP_QUATERNION__bindgen_ty_1__bindgen_ty_1;
 
     fn deref(&self) -> &Self::Target {
@@ -40,15 +40,15 @@ impl<'a> core::ops::Deref for Quaternion<'a> {
 }
 
 #[cfg(feature = "glam")]
-impl From<Quaternion<'_>> for glam::Quat {
-    fn from(q: Quaternion) -> glam::Quat {
+impl From<QuaternionRef<'_>> for glam::Quat {
+    fn from(q: QuaternionRef) -> glam::Quat {
         q.into_glam()
     }
 }
 
 #[cfg(feature = "nalgebra")]
-impl From<Quaternion<'_>> for nalgebra::UnitQuaternion<f32> {
-    fn from(q: Quaternion) -> nalgebra::UnitQuaternion<f32> {
+impl From<QuaternionRef<'_>> for nalgebra::UnitQuaternion<f32> {
+    fn from(q: QuaternionRef) -> nalgebra::UnitQuaternion<f32> {
         q.into_nalgebra()
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,5 +1,5 @@
 use derive_deref::Deref;
 use leap_sys::LEAP_VERSION;
 
-#[derive(Deref)]
+#[derive(Deref, Clone, Copy)]
 pub struct Version(pub(crate) LEAP_VERSION);


### PR DESCRIPTION
All the wrappers that just wrap references to native struct now:
 - Are suffixed with -Ref
 - Are implicitly copyable