### PR TITLE
Add MacOS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased] - yyyy-mm-dd
 
 ### Added
+- Support for MacOS
 
 ### Changed
 

--- a/build.rs
+++ b/build.rs
@@ -4,11 +4,11 @@ use std::{env, path::PathBuf};
 const DEFAULT_LEAPSDK_LIB_PATH: &str = r"C:\Program Files\Ultraleap\LeapSDK\lib\x64";
 
 #[cfg(target_os = "macos")]
-const DEFAULT_LEAPSDK_LIB_PATH: &str = r"/Applications/Ultraleap Hand Tracking.app/Contents/LeapSDK/lib";
+const DEFAULT_LEAPSDK_LIB_PATH: &str =
+    r"/Applications/Ultraleap Hand Tracking.app/Contents/LeapSDK/lib";
 
 #[cfg(target_os = "linux")]
 const DEFAULT_LEAPSDK_LIB_PATH: &str = r"/usr/share/doc/ultraleap-hand-tracking-service";
-
 
 fn main() {
     // Find Leap SDK

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,14 @@
 use std::{env, path::PathBuf};
 
-#[cfg(windows)]
+#[cfg(target_os = "windows")]
 const DEFAULT_LEAPSDK_LIB_PATH: &str = r"C:\Program Files\Ultraleap\LeapSDK\lib\x64";
 
-#[cfg(not(windows))]
+#[cfg(target_os = "macos")]
+const DEFAULT_LEAPSDK_LIB_PATH: &str = r"/Applications/Ultraleap Hand Tracking.app/Contents/LeapSDK/lib";
+
+#[cfg(target_os = "linux")]
 const DEFAULT_LEAPSDK_LIB_PATH: &str = r"/usr/share/doc/ultraleap-hand-tracking-service";
+
 
 fn main() {
     // Find Leap SDK

--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,7 @@ const DEFAULT_LEAPSDK_LIB_PATH: &str = r"/usr/share/doc/ultraleap-hand-tracking-
 
 fn main() {
     // Find Leap SDK
-    println!(r"cargo:rerun-if-env-changed=LEAPSDK_LIB_PATH");
+    println!(r"cargo::rerun-if-env-changed=LEAPSDK_LIB_PATH");
 
     let leapsdk_path =
         env::var("LEAPSDK_LIB_PATH").unwrap_or_else(|_| DEFAULT_LEAPSDK_LIB_PATH.to_string());
@@ -20,14 +20,14 @@ fn main() {
     let leapsdk_path = PathBuf::from(leapsdk_path);
 
     if !leapsdk_path.is_dir() {
-        println!("cargo:warning=Could not find LeapSDK at the location {}. Install it from https://developer.leapmotion.com/tracking-software-download or set its location with the environment variable LEAPSDK_LIB_PATH.", leapsdk_path.display());
+        println!("cargo::warning=Could not find LeapSDK at the location {}. Install it from https://developer.leapmotion.com/tracking-software-download or set its location with the environment variable LEAPSDK_LIB_PATH.", leapsdk_path.display());
     } else {
         let path_str = leapsdk_path
             .to_str()
             .unwrap_or_else(|| panic!("{} is not a valid path.", leapsdk_path.display()));
 
         // Link to LeapC.lib
-        println!(r"cargo:rustc-link-search={}", path_str);
-        println!(r"cargo:rustc-link-lib=LeapC");
+        println!(r"cargo::rustc-link-search={}", path_str);
+        println!(r"cargo::rustc-link-lib=LeapC");
     }
 }


### PR DESCRIPTION
This works for me on MacOS, although actually running the executable will produce an error unless explicitly giving a DYLD path, ie..
```
DYLD_LIBRARY_PATH="/Applications/Ultraleap Hand Tracking.app/Contents/LeapSDK/lib" cargo run
```

I think this is related to https://github.com/rust-lang/cargo/issues/4895